### PR TITLE
Added axos-manual to packages

### DIFF
--- a/axos-iso/packages.x86_64
+++ b/axos-iso/packages.x86_64
@@ -173,6 +173,7 @@ plymouth-theme-axos
 epsilon
 axuralis
 axctl
+axos-manual
 
 axos/grub
 axos/plymouth


### PR DESCRIPTION
Added axos-manual to live desktop packages.

Commands:

```bash
man axos # to see axos manual page 1

man axos.1 # to see axos manual page 1

man axos.7 # to see axos manual page 7

# Reset of the pages are skipped due to the reasons defined here: https://man7.org/linux/man-pages/man7/man-pages.7.html#DESCRIPTION
```

### Pages and their use:
- **Page-1**:  User commands (axinstall-cli manual)
- **Page-7**: Overview, conventions, and miscellaneous (axinstall manual - the gui one)